### PR TITLE
fix invalid use of ,string struct tag, trying to unmarshal unquoted value into float64

### DIFF
--- a/client_examples/websocket_sample_usage.go
+++ b/client_examples/websocket_sample_usage.go
@@ -3,7 +3,6 @@ package client_examples
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/falconxio/falconx-go/clients"
 	gosocketio "github.com/graarh/golang-socketio"
@@ -91,6 +90,6 @@ func RunWebSocketExamples(apiKey string, secret string, passphrase string, host 
 		ClientRequestID: "5c5325e3-ee42-76fa-932c-64dce446d8be",
 	})
 
-	wait:= make(chan bool, 1)
+	wait := make(chan bool, 1)
 	<-wait
 }

--- a/clients/datatype.go
+++ b/clients/datatype.go
@@ -123,7 +123,7 @@ type OrderResponse3 struct {
 	SellPrice     float64          `json:"sell_price"`
 	Platform      string           `json:"platform"`
 	TokenPair     TokenPair        `json:"token_pair"`
-	Quantity      Quantity         `json:"quantity_requested"`
+	Quantity      Quantity3        `json:"quantity_requested"`
 	SideRequested string           `json:"side_requested"`
 	QuoteTime     time.Time        `json:"t_quote"`
 	ExpiryTime    time.Time        `json:"t_expiry"`

--- a/clients/datatype.go
+++ b/clients/datatype.go
@@ -115,7 +115,7 @@ type Transfer struct {
 	Type       string    `json:"type"`
 	Platform   string    `json:"platform"`
 	Token      string    `json:"token"`
-	Quantity   float64   `json:"quantity,string"`
+	Quantity   float64   `json:"quantity"`
 	CreateTime time.Time `json:"t_create"`
 	Status     string    `json:"status"`
 }

--- a/clients/datatype.go
+++ b/clients/datatype.go
@@ -112,12 +112,15 @@ type TotalBalance struct {
 }
 
 type Transfer struct {
-	Type       string    `json:"type"`
-	Platform   string    `json:"platform"`
-	Token      string    `json:"token"`
-	Quantity   float64   `json:"quantity"`
-	CreateTime time.Time `json:"t_create"`
-	Status     string    `json:"status"`
+	Type            string     `json:"type"`
+	Platform        string     `json:"platform"`
+	Token           string     `json:"token"`
+	Quantity        float64    `json:"quantity"`
+	CreateTime      time.Time  `json:"t_create"`
+	Status          string     `json:"status"`
+	FxTransferID    string     `json:"fx_transfer_id"`
+	DeleteTime      *time.Time `json:"t_delete"`
+	TransactionHash string     `json:"transaction_hash"`
 }
 
 type TradeVolume struct {

--- a/clients/datatype.go
+++ b/clients/datatype.go
@@ -15,6 +15,11 @@ type Quantity struct {
 	Value float64 `json:"value,string"`
 }
 
+type Quantity3 struct {
+	Token string  `json:"token"`
+	Value float64 `json:"value"`
+}
+
 type QuoteRequest struct {
 	TokenPair     TokenPair `json:"token_pair"`
 	Quantity      Quantity  `json:"quantity"`
@@ -25,6 +30,17 @@ type QuoteRequest struct {
 type OrderRequest struct {
 	TokenPair     TokenPair `json:"token_pair"`
 	Quantity      Quantity  `json:"quantity"`
+	Side          string    `json:"side"`
+	OrderType     string    `json:"order_type"`
+	TimeInForce   string    `json:"time_in_force"`
+	LimitPrice    float64   `json:"limit_price"`
+	SlippageBps   float64   `json:"slippage_bps"`
+	ClientOrderId string    `json:"client_order_id"`
+}
+
+type OrderRequest3 struct {
+	TokenPair     TokenPair `json:"token_pair"`
+	Quantity      Quantity3 `json:"quantity"`
 	Side          string    `json:"side"`
 	OrderType     string    `json:"order_type"`
 	TimeInForce   string    `json:"time_in_force"`
@@ -95,6 +111,36 @@ type OrderResponse struct {
 	TimeInForce   string           `json:"time_in_force"`
 	LimitPrice    float64          `json:"limit_price,string"`
 	SlippageBps   float64          `json:"slippage_bps,string"`
+	Error         FalconXError     `json:"error"`
+	Warnings      []FalconXWarning `json:"warnings"`
+	ClientOrderId string           `json:"client_order_id"`
+}
+
+type OrderResponse3 struct {
+	Status        string           `json:"status"`
+	FxQuoteId     string           `json:"fx_quote_id"`
+	BuyPrice      float64          `json:"buy_price"`
+	SellPrice     float64          `json:"sell_price"`
+	Platform      string           `json:"platform"`
+	TokenPair     TokenPair        `json:"token_pair"`
+	Quantity      Quantity         `json:"quantity_requested"`
+	SideRequested string           `json:"side_requested"`
+	QuoteTime     time.Time        `json:"t_quote"`
+	ExpiryTime    time.Time        `json:"t_expiry"`
+	ExecutionTime time.Time        `json:"t_execute"`
+	IsFilled      bool             `json:"is_filled"`
+	GrossFeeBps   float64          `json:"gross_fee_bps"`
+	GrossFeeUSD   float64          `json:"gross_fee_usd"`
+	RebateBps     float64          `json:"rebate_bps"`
+	RebateUSD     float64          `json:"rebate_usd"`
+	FeeBps        float64          `json:"fee_bps"`
+	FeeUSD        float64          `json:"fee_usd"`
+	SideExecuted  string           `json:"side_executed"`
+	TraderEmail   string           `json:"trader_email"`
+	OrderType     string           `json:"order_type"`
+	TimeInForce   string           `json:"time_in_force"`
+	LimitPrice    float64          `json:"limit_price"`
+	SlippageBps   float64          `json:"slippage_bps"`
 	Error         FalconXError     `json:"error"`
 	Warnings      []FalconXWarning `json:"warnings"`
 	ClientOrderId string           `json:"client_order_id"`

--- a/clients/datatype.go
+++ b/clients/datatype.go
@@ -83,12 +83,12 @@ type OrderResponse struct {
 	ExpiryTime    time.Time        `json:"t_expiry"`
 	ExecutionTime time.Time        `json:"t_execute"`
 	IsFilled      bool             `json:"is_filled"`
-	GrossFeeBps   float64          `json:"gross_fee_bps,string"`
-	GrossFeeUSD   float64          `json:"gross_fee_usd,string"`
-	RebateBps     float64          `json:"rebate_bps,string"`
-	RebateUSD     float64          `json:"rebate_usd,string"`
-	FeeBps        float64          `json:"fee_bps,string"`
-	FeeUSD        float64          `json:"fee_usd,string"`
+	GrossFeeBps   float64          `json:"gross_fee_bps"`
+	GrossFeeUSD   float64          `json:"gross_fee_usd"`
+	RebateBps     float64          `json:"rebate_bps"`
+	RebateUSD     float64          `json:"rebate_usd"`
+	FeeBps        float64          `json:"fee_bps"`
+	FeeUSD        float64          `json:"fee_usd"`
 	SideExecuted  string           `json:"side_executed"`
 	TraderEmail   string           `json:"trader_email"`
 	OrderType     string           `json:"order_type"`

--- a/clients/rest_client.go
+++ b/clients/rest_client.go
@@ -318,6 +318,14 @@ func (client *RestClient) GetExecutedQuotes(tStart time.Time, tEnd time.Time) ([
 	return result, err
 }
 
+func (client *RestClient) GetExecutedQuotesAll(tStart time.Time, tEnd time.Time) ([]QuoteResponse, error) {
+	var result []QuoteResponse
+	// NS: we don't specify the platform so we can get all trades
+	requestParams := map[string]string{"t_start": tStart.Format(time.RFC3339), "t_end": tEnd.Format(time.RFC3339)}
+	_, err := client.Request("GET", "/v1/quotes", requestParams, &result)
+	return result, err
+}
+
 // GetBalances gets account balances.
 //         :param platform: possible values -> ('browser', 'api', 'margin')
 //             Example:

--- a/clients/rest_client.go
+++ b/clients/rest_client.go
@@ -350,7 +350,7 @@ func (client *RestClient) GetBalances() ([]Balance, error) {
 //                 ]
 func (client *RestClient) GetTransfers(tStart time.Time, tEnd time.Time) ([]Transfer, error) {
 	var result []Transfer
-	requestParams := map[string]string{"t_start": tStart.Format(time.RFC3339), "t_end": tEnd.Format(time.RFC3339), "platform": "api"}
+	requestParams := map[string]string{"t_start": tStart.Format(time.RFC3339), "t_end": tEnd.Format(time.RFC3339)}
 	_, err := client.Request("GET", "/v1/transfers", requestParams, &result)
 	return result, err
 }

--- a/clients/rest_client.go
+++ b/clients/rest_client.go
@@ -229,6 +229,12 @@ func (client *RestClient) PlaceOrder(orderParams OrderRequest) (OrderResponse, e
 	return result, err
 }
 
+func (client *RestClient) PlaceOrder3(orderParams OrderRequest3) (OrderResponse3, error) {
+	var result OrderResponse3
+	_, err := client.Request("POST", "/v3/order", orderParams, &result)
+	return result, err
+}
+
 // ExecuteQuote executes the quote.
 //         :param fx_quote_id: (str) the quote id received via get_quote
 //         :param side: (str) must be either buy or sell

--- a/clients/rest_client.go
+++ b/clients/rest_client.go
@@ -145,6 +145,36 @@ func (client *RestClient) GetTradingPairs() ([]TokenPair, error) {
 	return result, nil
 }
 
+type QuoteResponse3 struct {
+	Status          string           `json:"status"`
+	FxQuoteId       string           `json:"fx_quote_id"`
+	ClientOrderId   *string          `json:"client_order_id"`
+	ClientOrderUuid *string          `json:"client_order_uuid"`
+	Platform        string           `json:"platform"`
+	TokenPair       TokenPair        `json:"token_pair"`
+	Quantity        Quantity3        `json:"quantity_requested"`
+	SideRequested   string           `json:"side_requested"`
+	QuoteTime       time.Time        `json:"t_quote"`
+	ExpiryTime      time.Time        `json:"t_expiry"`
+	ExecutionTime   *time.Time       `json:"t_execute"` // Nullable field
+	IsFilled        bool             `json:"is_filled"`
+	GrossFeeBps     float64          `json:"gross_fee_bps"`
+	GrossFeeUsd     float64          `json:"gross_fee_usd"`
+	RebateBps       float64          `json:"rebate_bps"`
+	RebateUsd       float64          `json:"rebate_usd"`
+	FeeBps          float64          `json:"fee_bps"`
+	FeeUsd          float64          `json:"fee_usd"`
+	SideExecuted    *string          `json:"side_executed"` // Nullable field
+	TraderEmail     string           `json:"trader_email"`
+	OrderType       string           `json:"order_type"`
+	Error           *FalconXError    `json:"error"`
+	PositionIn      Quantity3        `json:"position_in"`
+	PositionOut     Quantity3        `json:"position_out"`
+	Warnings        []FalconXWarning `json:"warnings"`
+	BuyPrice        float64          `json:"buy_price"`
+	SellPrice       float64          `json:"sell_price"`
+}
+
 // GetQuote gets a two_way, buy or sell quote for a token pair.
 //         :param base: (str) base token e.g. BTC, ETH
 //         :param quote: (str) quote token e.g. USD, BTC
@@ -176,7 +206,12 @@ func (client *RestClient) GetTradingPairs() ([]TokenPair, error) {
 func (client *RestClient) GetQuote(quoteParams QuoteRequest) (QuoteResponse, error) {
 	var result QuoteResponse
 	_, err := client.Request("POST", "/v1/quotes", quoteParams, &result)
+	return result, err
+}
 
+func (client *RestClient) GetQuote3(quoteParams QuoteRequest) (QuoteResponse3, error) {
+	var result QuoteResponse3
+	_, err := client.Request("POST", "/v3/quotes", quoteParams, &result)
 	return result, err
 }
 


### PR DESCRIPTION
I’m getting this error when unmarshaling the response from PlaceOrder:
`json: invalid use of ,string struct tag, trying to unmarshal unquoted value into float64`

I believe this is because the API may have changed and the SDK was not updated.

The values I've updated were the ones that were giving an error, which when removed they worked correctly without any error message

There are other instances of `,string` in the file as well but when I removed some of them they gave an error so I assume the API response for some items are still coming in as a `string` while for others they are coming in as float values.
